### PR TITLE
Concat suite info to be available to each test case's templating.

### DIFF
--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -38,6 +38,11 @@ describe('buildJsonResults', () => {
     expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.classname).toBe('1');
   });
 
+  it('should return the proper classname when classNameTemplate is customized with Suite property', () => {
+    const jsonResults = getResults('failing-tests.json', {'classNameTemplate': '{errorCount}'});
+    expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.classname).toBe('0');
+  });
+
   it('should return empty when classNameTemplate is customized with a bad key', () => {
     const jsonResults = getResults('failing-tests.json', {'classNameTemplate': '{bad}'});
     expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.classname).toBe('');

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -41,12 +41,14 @@ module.exports = function buildJsonResults (report, appDirectory, options) {
 
     // Iterate through test cases
     suite.messages.forEach((tc) => {
+      const obj = Object.assign({}, suite, tc);
+
       const testCase = {
         'testcase': [
           {
             '_attr': {
-              'classname': buildTemplate(options.classNameTemplate, tc),
-              'name': buildTemplate(options.titleTemplate, tc),
+              'classname': buildTemplate(options.classNameTemplate, obj),
+              'name': buildTemplate(options.titleTemplate, obj),
               'time': 1
             }
           }


### PR DESCRIPTION
In our case, our JUnit renderer disregards `testsuite` info. This makes it impossible from the UI to tell which file the error is in. With this change, setting `ESLINT_JUNIT_TITLE="{filePath}"` fixes this for us.